### PR TITLE
Add methods for quick text positionning

### DIFF
--- a/JMHoledView/JMHoledView/JMHoledView.h
+++ b/JMHoledView/JMHoledView/JMHoledView.h
@@ -15,6 +15,17 @@ typedef NS_ENUM(NSInteger, JMHoleType)
     JMHoleTypeRoundedRect,
     JMHoleTypeCustomRect
 };
+typedef NS_ENUM(NSInteger, JMHolePosition)
+{
+    JMPositionTop,
+    JMPositionTopRightCorner,
+    JMPositionRight,
+    JMPositionBottomRightCorner,
+    JMPositionBottom,
+    JMPositionBottomLeftCorner,
+    JMPositionLeft,
+    JMPositionTopLeftCorner
+};
 
 @class JMHoledView;
 @protocol JMHoledViewDelegate <NSObject>
@@ -33,6 +44,11 @@ typedef NS_ENUM(NSInteger, JMHoleType)
 - (NSInteger)addHoleRectOnRect:(CGRect)rect;
 - (NSInteger)addHoleRoundedRectOnRect:(CGRect)rect withCornerRadius:(CGFloat)cornerRadius;
 - (NSInteger)addHCustomView:(UIView *)customView onRect:(CGRect)rect;
+
+- (void) addHoleCircleCenteredOnPosition:(CGPoint)centerPoint andDiameter:(CGFloat)diameter withText:(NSString *)text onPosition:(JMHolePosition)position withMargin:(CGFloat) margin;
+- (void) addHoleRectOnRect:(CGRect)rect withText:(NSString *)text onPosition:(JMHolePosition)position withMargin:(CGFloat) margin;
+- (void) addHoleRoundedRectOnRect:(CGRect)rect withCornerRadius:(CGFloat)cornerRadius withText:(NSString *)text onPosition:(JMHolePosition)position withMargin:(CGFloat) margin;
+
 
 - (void)removeHoles;
 

--- a/JMHoledView/JMHoledView/JMHoledView.m
+++ b/JMHoledView/JMHoledView/JMHoledView.m
@@ -9,6 +9,7 @@
 #import "JMHoledView.h"
 
 #pragma mark - holes objects
+#define SYSTEM_VERSION_LESS_THAN(v) ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedAscending)
 
 @interface JMHole : NSObject
 @property (assign) JMHoleType holeType;
@@ -183,11 +184,103 @@
     return [self.holes indexOfObject:customHole];
 }
 
+- (void) addHoleCircleCenteredOnPosition:(CGPoint)centerPoint andDiameter:(CGFloat)diameter withText:(NSString *)text onPosition:(JMHolePosition) pos withMargin:(CGFloat) margin
+{
+    
+    [self addHoleCircleCenteredOnPosition:centerPoint andDiameter:diameter];
+    [self buildLabel:centerPoint holeWidth:diameter holeHeight:diameter withText:text onPosition:pos withMargin:margin];
+    
+}
+
+- (void) addHoleRectOnRect:(CGRect)rect withText:(NSString *)text onPosition:(JMHolePosition) pos withMargin:(CGFloat) margin
+{
+    [self addHoleRectOnRect:rect];
+    [self buildLabel:CGPointMake(rect.origin.x+(rect.size.width/2),rect.origin.y+(rect.size.height/2)) holeWidth:rect.size.width holeHeight:rect.size.height withText:text onPosition:pos withMargin:margin];
+}
+
+-(void) addHoleRoundedRectOnRect:(CGRect)rect withCornerRadius:(CGFloat)cornerRadius withText:(NSString *)text onPosition:(JMHolePosition) pos withMargin:(CGFloat) margin
+{
+    [self addHoleRoundedRectOnRect:rect withCornerRadius:cornerRadius];
+    [self buildLabel:CGPointMake(rect.origin.x+(rect.size.width/2),rect.origin.y+(rect.size.height/2)) holeWidth:rect.size.width holeHeight:rect.size.height withText:text onPosition:pos withMargin:margin];
+}
+
 - (void)removeHoles
 {
     [self removeCustomViews];
     [self.holes removeAllObjects];
     [self setNeedsDisplay];
+}
+
+-(UILabel*) buildLabel:(CGPoint)point holeWidth:(CGFloat)width holeHeight:(CGFloat)height withText:(NSString*) text onPosition:(JMHolePosition) pos withMargin:(CGFloat) margin{
+    
+    CGPoint centerPoint = point;
+    CGFloat holeWidthHalf = (width/2) + margin;
+    CGFloat holeHeightHalf = (height/2) + margin;
+    
+    CGRect frame;
+    CGSize fontSize;
+    if (SYSTEM_VERSION_LESS_THAN(@"7.0")) {
+        // code here for iOS 5.0,6.0 and so on
+        fontSize = [text sizeWithFont:[UIFont systemFontOfSize:14.0f]];
+    } else {
+        // code here for iOS 7.0
+        fontSize = [text sizeWithAttributes:
+                    @{NSFontAttributeName:
+                          [UIFont systemFontOfSize:14.0f]}];
+    }
+    CGFloat x;
+    CGFloat y;
+    switch (pos) {
+        case JMPositionTop:
+            x = (centerPoint.x)-(fontSize.width/2);
+            y = (centerPoint.y-holeHeightHalf)-fontSize.height;
+            break;
+        case JMPositionTopRightCorner:
+            x = (centerPoint.x+holeWidthHalf);
+            y = (centerPoint.y-holeHeightHalf)-fontSize.height;
+            break;
+        case JMPositionRight:
+            x = (centerPoint.x+holeWidthHalf);
+            y = (centerPoint.y)-(fontSize.height/2);
+            break;
+        case JMPositionBottomRightCorner:
+            x = centerPoint.x+holeWidthHalf;
+            y = centerPoint.y+holeHeightHalf;
+            break;
+        case JMPositionBottom:
+            x = (centerPoint.x)-(fontSize.width/2);
+            y = (centerPoint.y+holeHeightHalf);
+            break;
+        case JMPositionBottomLeftCorner:
+            x = (centerPoint.x-holeWidthHalf)-(fontSize.width);
+            y = (centerPoint.y+holeHeightHalf);
+            break;
+        case JMPositionLeft:
+            x = (centerPoint.x-holeWidthHalf)-(fontSize.width);
+            y = (centerPoint.y)-(fontSize.height/2);
+            break;
+        case JMPositionTopLeftCorner:
+            x = (centerPoint.x-holeWidthHalf)-(fontSize.width);
+            y = (centerPoint.y-holeHeightHalf)-(fontSize.height/2);
+            break;
+        default:
+            x = centerPoint.x;
+            y = centerPoint.y;
+            break;
+    }
+    frame = CGRectMake(x,y, fontSize.width, fontSize.height);
+    
+    UILabel *label = [[UILabel alloc] initWithFrame:frame];
+    [label setBackgroundColor:[UIColor clearColor]];
+    [label setTextColor:[UIColor whiteColor]];
+    label.numberOfLines = 2;
+    label.text = text;
+    label.font = [UIFont systemFontOfSize:14.0f];
+    label.textAlignment = NSTextAlignmentCenter;
+    
+    [self addHCustomView:label onRect:frame];
+    
+    return label;
 }
 
 #pragma mark - Overided setter

--- a/JMHoledView/JMViewController.m
+++ b/JMHoledView/JMViewController.m
@@ -36,7 +36,15 @@
 - (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error
 {
     self.holedView.holeViewDelegate = self;
-    [self.holedView addHoleRoundedRectOnRect:CGRectMake(10.0f, 250.0f, 300.0f, 30.0f) withCornerRadius:10.0f];
+    [self.holedView addHoleCircleCenteredOnPosition:CGPointMake(150.0f, 50.0f) andDiameter:40.0f withText:@"Left Text" onPosition:JMPositionLeft withMargin:10.0f];
+    [self.holedView addHoleCircleCenteredOnPosition:CGPointMake(150.0f, 100.0f) andDiameter:40.0f withText:@"Right Text" onPosition:JMPositionRight withMargin:10.0f];
+    [self.holedView addHoleCircleCenteredOnPosition:CGPointMake(150.0f, 160.0f) andDiameter:40.0f withText:@"Top Text" onPosition:JMPositionTop withMargin:0];
+    [self.holedView addHoleCircleCenteredOnPosition:CGPointMake(150.0f, 210.0f) andDiameter:40.0f withText:@"Bottom Text" onPosition:JMPositionBottom withMargin:0];
+    
+    [self.holedView addHoleCircleCenteredOnPosition:CGPointMake(100.0f, 300.0f) andDiameter:40.0f withText:@"Top Left" onPosition:JMPositionTopLeftCorner withMargin:0];
+    [self.holedView addHoleCircleCenteredOnPosition:CGPointMake(200.0f, 300.0f) andDiameter:40.0f withText:@"Top Right" onPosition:JMPositionTopRightCorner withMargin:0];
+    [self.holedView addHoleCircleCenteredOnPosition:CGPointMake(100.0f, 350.0f) andDiameter:40.0f withText:@"Bottom Left" onPosition:JMPositionBottomLeftCorner withMargin:0];
+    [self.holedView addHoleCircleCenteredOnPosition:CGPointMake(200.0f, 350.0f) andDiameter:40.0f withText:@"Bottom Right" onPosition:JMPositionBottomRightCorner withMargin:0];
 }
 
 #pragma mark - JMHoledViewDelegate

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ A view design to be filled with holes ...
 - (NSInteger)addHoleRectOnRect:(CGRect)rect;
 - (NSInteger)addHoleRoundedRectOnRect:(CGRect)rect withCornerRadius:(CGFloat)cornerRadius;
 - (NSInteger)addHCustomView:(UIView *)customView onRect:(CGRect)rect;
+
+- (void) addHoleCircleCenteredOnPosition:(CGPoint)centerPoint andDiameter:(CGFloat)diameter withText:(NSString *)text onPosition:(JMHolePosition)position withMargin:(CGFloat) margin;
+- (void) addHoleRectOnRect:(CGRect)rect withText:(NSString *)text onPosition:(JMHolePosition)position withMargin:(CGFloat) margin;
+- (void) addHoleRoundedRectOnRect:(CGRect)rect withCornerRadius:(CGFloat)cornerRadius withText:(NSString *)text onPosition:(JMHolePosition)position withMargin:(CGFloat) margin;
 ```
 
 


### PR DESCRIPTION
This enables to place a text in height positions around the hole:

``` objc
JMPositionTop
JMPositionTopRightCorner
JMPositionRight
JMPositionBottomRightCorner
JMPositionBottom
JMPositionBottomLeftCorner
JMPositionLeft
JMPositionTopLeftCorner
```

``` objc
- (void) addHoleCircleCenteredOnPosition:(CGPoint)centerPoint andDiameter:(CGFloat)diameter withText:(NSString *)text onPosition:(JMHolePosition)position withMargin:(CGFloat) margin;
- (void) addHoleRectOnRect:(CGRect)rect withText:(NSString *)text onPosition:(JMHolePosition)position withMargin:(CGFloat) margin;
- (void) addHoleRoundedRectOnRect:(CGRect)rect withCornerRadius:(CGFloat)cornerRadius withText:(NSString *)text onPosition:(JMHolePosition)position withMargin:(CGFloat) margin;
```
