### PR TITLE
iOS 7 & attributed string

### DIFF
--- a/JMHoledView.podspec
+++ b/JMHoledView.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
 
   s.license      = 'MIT'
   s.author       = { "jerome Morissard" => "morissardj@gmail.com" }
-  s.platform     = :ios, '5.0'
+  s.platform     = :ios, '7.0'
   s.source       = { :git => "https://github.com/leverdeterre/JMHoledView.git", :tag => "0.2.0" }
   s.source_files = 'Classes', 'JMHoledView/JMHoledView/*.{h,m}'
   s.public_header_files = 'JMHoledView/JMHoledView/*.h'

--- a/JMHoledView/JMHoledView/JMHoledView.h
+++ b/JMHoledView/JMHoledView/JMHoledView.h
@@ -30,7 +30,9 @@ typedef NS_ENUM(NSInteger, JMHolePosition)
 @class JMHoledView;
 @protocol JMHoledViewDelegate <NSObject>
 
+@optional
 - (void)holedView:(JMHoledView *)holedView didSelectHoleAtIndex:(NSUInteger)index;
+- (void)holedView:(JMHoledView *)holedView willAddLabel:(UILabel*)label;
 
 @end
 

--- a/JMHoledView/JMHoledView/JMHoledView.h
+++ b/JMHoledView/JMHoledView/JMHoledView.h
@@ -39,6 +39,7 @@ typedef NS_ENUM(NSInteger, JMHolePosition)
 
 @property (strong, nonatomic) UIColor *dimingColor;
 @property (weak, nonatomic) id <JMHoledViewDelegate> holeViewDelegate;
+@property (strong, nonatomic) UIFont *textFont;
 
 - (NSInteger)addHoleCircleCenteredOnPosition:(CGPoint)centerPoint
                                     diameter:(CGFloat)diamter;

--- a/JMHoledView/JMHoledView/JMHoledView.h
+++ b/JMHoledView/JMHoledView/JMHoledView.h
@@ -32,7 +32,7 @@ typedef NS_ENUM(NSInteger, JMHolePosition)
 
 @optional
 - (void)holedView:(JMHoledView *)holedView didSelectHoleAtIndex:(NSUInteger)index;
-- (void)holedView:(JMHoledView *)holedView willAddLabel:(UILabel*)label;
+- (void)holedView:(JMHoledView *)holedView willAddLabel:(UILabel*)label atIndex:(NSUInteger)index;
 
 @end
 

--- a/JMHoledView/JMHoledView/JMHoledView.h
+++ b/JMHoledView/JMHoledView/JMHoledView.h
@@ -74,6 +74,12 @@ typedef NS_ENUM(NSInteger, JMHolePosition)
                       onPosition:(JMHolePosition)position
                           margin:(CGFloat)margin;
 
+- (void)addHoleRoundedRectOnRect:(CGRect)rect
+                    cornerRadius:(CGFloat)cornerRadius
+                            attributedText:(NSAttributedString *)text
+                      onPosition:(JMHolePosition)position
+                          margin:(CGFloat)margin;
+
 - (void)removeHoles;
 
 @end

--- a/JMHoledView/JMHoledView/JMHoledView.m
+++ b/JMHoledView/JMHoledView/JMHoledView.m
@@ -322,7 +322,12 @@
     label.font = self.textFont;
     label.textAlignment = NSTextAlignmentCenter;
     
-    [self addHCustomView:label onRect:frame];
+    if ([self.holeViewDelegate respondsToSelector:@selector(holedView:willAddLabel:)])
+    {
+        [self.holeViewDelegate holedView:self willAddLabel:label];
+    }
+    
+    [self addHCustomView:label onRect:label.frame];
     
     return label;
 }

--- a/JMHoledView/JMHoledView/JMHoledView.m
+++ b/JMHoledView/JMHoledView/JMHoledView.m
@@ -85,6 +85,7 @@
 
 - (void)setup
 {
+    _textFont = [UIFont systemFontOfSize:14.0f];
     _holes = [NSMutableArray new];
     self.backgroundColor = [UIColor clearColor];
     _dimingColor = [[UIColor blackColor] colorWithAlphaComponent:0.5f];
@@ -261,12 +262,15 @@
     CGSize fontSize;
     if (SYSTEM_VERSION_LESS_THAN(@"7.0")) {
         // code here for iOS 5.0,6.0 and so on
-        fontSize = [text sizeWithFont:[UIFont systemFontOfSize:14.0f]];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        fontSize = [text sizeWithFont:self.textFont];
+#pragma clang diagnostic pop
     } else {
         // code here for iOS 7.0
         fontSize = [text sizeWithAttributes:
                     @{NSFontAttributeName:
-                          [UIFont systemFontOfSize:14.0f]}];
+                          self.textFont}];
     }
     CGFloat x;
     CGFloat y;
@@ -315,7 +319,7 @@
     [label setTextColor:[UIColor whiteColor]];
     label.numberOfLines = 2;
     label.text = text;
-    label.font = [UIFont systemFontOfSize:14.0f];
+    label.font = self.textFont;
     label.textAlignment = NSTextAlignmentCenter;
     
     [self addHCustomView:label onRect:frame];

--- a/JMHoledView/JMHoledView/JMHoledView.m
+++ b/JMHoledView/JMHoledView/JMHoledView.m
@@ -322,9 +322,14 @@
     label.font = self.textFont;
     label.textAlignment = NSTextAlignmentCenter;
     
-    if ([self.holeViewDelegate respondsToSelector:@selector(holedView:willAddLabel:)])
+    if ([self.holeViewDelegate respondsToSelector:@selector(holedView:willAddLabel:atIndex:)])
     {
-        [self.holeViewDelegate holedView:self willAddLabel:label];
+        NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(JMHole *evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings) {
+            return ![evaluatedObject isKindOfClass:[JMCustomRectHole class]];
+        }];
+        NSArray *labels = [self.holes filteredArrayUsingPredicate:predicate];
+        NSInteger index = labels.count-1;
+        [self.holeViewDelegate holedView:self willAddLabel:label atIndex:index];
     }
     
     [self addHCustomView:label onRect:label.frame];

--- a/JMHoledView/JMHoledView/JMHoledView.m
+++ b/JMHoledView/JMHoledView/JMHoledView.m
@@ -317,7 +317,7 @@
     UILabel *label = [[UILabel alloc] initWithFrame:frame];
     [label setBackgroundColor:[UIColor clearColor]];
     [label setTextColor:[UIColor whiteColor]];
-    label.numberOfLines = 2;
+    label.numberOfLines = 0;
     label.text = text;
     label.font = self.textFont;
     label.textAlignment = NSTextAlignmentCenter;

--- a/JMHoledView/JMHoledView/JMHoledView.m
+++ b/JMHoledView/JMHoledView/JMHoledView.m
@@ -240,6 +240,26 @@
               margin:margin];
 }
 
+
+
+- (void)addHoleRoundedRectOnRect:(CGRect)rect
+                    cornerRadius:(CGFloat)cornerRadius
+                  attributedText:(NSAttributedString *)text
+                      onPosition:(JMHolePosition)position
+                          margin:(CGFloat)margin
+{
+    [self addHoleRoundedRectOnRect:rect
+                      cornerRadius:cornerRadius];
+    
+    [self buildLabel:CGPointMake(rect.origin.x+(rect.size.width/2),rect.origin.y+(rect.size.height/2))
+           holeWidth:rect.size.width
+          holeHeight:rect.size.height
+            attrText:text
+          onPosition:position
+              margin:margin];
+    
+}
+
 - (void)removeHoles
 {
     [self removeCustomViews];
@@ -250,30 +270,22 @@
 -(UILabel*)buildLabel:(CGPoint)point
             holeWidth:(CGFloat)width
            holeHeight:(CGFloat)height
-                 text:(NSString*)text
+                 attrText:(NSAttributedString*)attrText
            onPosition:(JMHolePosition)pos
                margin:(CGFloat) margin
 {
+    NSString *text = attrText.string;
     CGPoint centerPoint = point;
     CGFloat holeWidthHalf = (width/2) + margin;
     CGFloat holeHeightHalf = (height/2) + margin;
     
     CGRect frame;
-    CGSize fontSize;
-    if (SYSTEM_VERSION_LESS_THAN(@"7.0")) {
-        // code here for iOS 5.0,6.0 and so on
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-        fontSize = [text sizeWithFont:self.textFont];
-#pragma clang diagnostic pop
-    } else {
-        // code here for iOS 7.0
-        fontSize = [text sizeWithAttributes:
-                    @{NSFontAttributeName:
-                          self.textFont}];
-    }
     CGFloat x;
     CGFloat y;
+    
+    NSDictionary *attrs = [attrText attributesAtIndex:0 longestEffectiveRange:nil inRange:NSMakeRange(0, text.length)];
+    CGSize fontSize = [text sizeWithAttributes:
+                attrs];
     switch (pos) {
         case JMPositionTop:
             x = (centerPoint.x)-(fontSize.width/2);
@@ -318,9 +330,8 @@
     [label setBackgroundColor:[UIColor clearColor]];
     [label setTextColor:[UIColor whiteColor]];
     label.numberOfLines = 0;
-    label.text = text;
-    label.font = self.textFont;
     label.textAlignment = NSTextAlignmentCenter;
+    label.attributedText = attrText;
     
     if ([self.holeViewDelegate respondsToSelector:@selector(holedView:willAddLabel:atIndex:)])
     {
@@ -334,6 +345,22 @@
     
     [self addHCustomView:label onRect:label.frame];
     
+    return label;
+}
+
+-(UILabel*)buildLabel:(CGPoint)point
+            holeWidth:(CGFloat)width
+           holeHeight:(CGFloat)height
+                 text:(NSString*)text
+           onPosition:(JMHolePosition)pos
+               margin:(CGFloat) margin
+{
+    NSAttributedString *attrString = [[NSAttributedString alloc] initWithString:text
+                                                                     attributes:@{
+                                                                                  NSFontAttributeName:
+                                                                                      self.textFont
+                                                                                  }];
+   UILabel *label = [self buildLabel:point holeWidth:width holeHeight:height attrText:attrString onPosition:pos margin:margin];
     return label;
 }
 

--- a/JMHoledView/JMViewController.m
+++ b/JMHoledView/JMViewController.m
@@ -36,18 +36,19 @@
 - (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error
 {
     self.holedView.holeViewDelegate = self;
-    [self.holedView addHoleCircleCenteredOnPosition:CGPointMake(150.0f, 50.0f) diameter:40.0f text:@"Left Text" onPosition:JMPositionLeft margin:10.0f];
+    [self.holedView addHoleCircleCenteredOnPosition:CGPointMake(150.0f, 50.0f) diameter:40.0f text:@"Left text!\n*conditions apply" onPosition:JMPositionLeft margin:10.0f];
     [self.holedView addHoleCircleCenteredOnPosition:CGPointMake(150.0f, 100.0f) diameter:40.0f text:@"Right Text" onPosition:JMPositionRight margin:10.0f];
     [self.holedView addHoleCircleCenteredOnPosition:CGPointMake(150.0f, 160.0f) diameter:40.0f text:@"Top Text" onPosition:JMPositionTop margin:0];
     [self.holedView addHoleCircleCenteredOnPosition:CGPointMake(150.0f, 210.0f) diameter:40.0f text:@"Bottom Text" onPosition:JMPositionBottom margin:0];
+    
+    // test add oval hole at bottom without label, so no delegate fire for this
+    [self.holedView addHoleCircleCenteredOnPosition:CGPointMake(150.0f, 450.0f) diameter:50 hScale:0.5f];
     
     [self.holedView addHoleCircleCenteredOnPosition:CGPointMake(100.0f, 300.0f) diameter:40.0f text:@"Top Left" onPosition:JMPositionTopLeftCorner margin:0];
     [self.holedView addHoleCircleCenteredOnPosition:CGPointMake(200.0f, 300.0f) diameter:40.0f text:@"Top Right" onPosition:JMPositionTopRightCorner margin:0];
     [self.holedView addHoleCircleCenteredOnPosition:CGPointMake(100.0f, 350.0f) diameter:40.0f text:@"Bottom Left" onPosition:JMPositionBottomLeftCorner margin:0];
     [self.holedView addHoleCircleCenteredOnPosition:CGPointMake(200.0f, 350.0f) diameter:40.0f text:@"Bottom Right" onPosition:JMPositionBottomRightCorner margin:0];
     
-    // test add oval hole
-    [self.holedView addHoleCircleCenteredOnPosition:CGPointMake(150.0f, 450.0f) diameter:50 hScale:0.5f];
 }
 
 #pragma mark - JMHoledViewDelegate
@@ -55,6 +56,25 @@
 - (void)holedView:(JMHoledView *)holedView didSelectHoleAtIndex:(NSUInteger)index
 {
     NSLog(@"%s %ld", __PRETTY_FUNCTION__,(long)index);
+}
+
+-(void)holedView:(JMHoledView *)holedView willAddLabel:(UILabel *)label atIndex:(NSUInteger)index
+{
+    if (index == 0)
+    {
+        label.layer.cornerRadius = 3.f;
+        label.layer.borderWidth = 1.f;
+        label.layer.borderColor = [UIColor whiteColor].CGColor;
+        
+        CGFloat margin = label.layer.borderWidth + 4;
+        CGRect frame = label.frame;
+        frame.origin.x -= margin;
+        frame.origin.y -= margin;
+        frame.size.width += margin*2;
+        frame.size.height += margin*2;
+        label.frame = frame;
+    }
+    
 }
 
 #pragma marl - helper


### PR DESCRIPTION
Bumped version to iOS 7 to remove checks;
Added additional addRect method to have attributedString, instead of just text;
Updated existing buildLabel to contain attributed text, but also to be compatible with simple string;
Additional label configuration available (from my master branch);

P. S. Please let me know if You even plan to merge this and push new version as I have to make another CocoaPod lib otherwise. These changes are needed for me.